### PR TITLE
✨ feat(users): add `/users/admins` endpoint to fetch admin users only

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -33,6 +33,20 @@ export const getUserById: RequestHandler = async (
   }
 };
 
+// Get all admin users
+export const getAdminUsers: RequestHandler = async (
+  req,
+  res,
+  next
+): Promise<void> => {
+  try {
+    const admins = await userService.getAdminUsers();
+    res.status(200).json(admins);
+  } catch (error) {
+    next(error);
+  }
+};
+
 // Create a new user
 export const createUser: RequestHandler = async (
   req,
@@ -107,3 +121,5 @@ export const deleteUser: RequestHandler = async (
     next(error); 
   }
 };
+
+

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { getUsers, getUserById, createUser, updateUserRole, updateUserProfile, deleteUser } from "../controllers/userController";
+import { getUsers, getUserById, createUser, updateUserRole, updateUserProfile, deleteUser, getAdminUsers } from "../controllers/userController";
 import { authenticateUser, authorizeAdmin } from "../middleware/authMiddleware";
 
 const router = express.Router();
@@ -14,6 +14,37 @@ const router = express.Router();
 // ------------------------------------------
 // 🔐 Admin Routes
 // ------------------------------------------
+/**
+ * @swagger
+ * /users/admins:
+ *   get:
+ *     summary: Get all users with admin role
+ *     tags: [Users]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved all admin users
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   _id:
+ *                     type: string
+ *                     example: "643abc123def4567890aaa11"
+ *                   username:
+ *                     type: string
+ *                     example: "adminUser"
+ *       401:
+ *         description: Unauthorized - No token provided
+ *       403:
+ *         description: Forbidden - Only admins can access
+ */
+router.get("/admins", authenticateUser, authorizeAdmin, getAdminUsers);
+
 /**
  * @swagger
  * /users:

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -22,6 +22,10 @@ export const getUserById = async (id: string): Promise<IUser | null> => {
   return await User.findById(id);
 };
 
+export const getAdminUsers = async (): Promise<IUser[]> => {
+  return await User.find({ role: "admin" }).select("_id username").exec();
+};
+
 export const updateUserRole = async (
   userId: string,
   newRole: "student" | "admin"


### PR DESCRIPTION
## 📌 Summary  
<!--    Explain what was added, removed, or modified. Keep it concise.  -->  
- Added a new `GET /api/users/admins` route to fetch users with the `admin` role  
- Created a `getAdminUsers` function in the service and controller layers  
- Updated Swagger documentation 

## 🔍 Why this change?  
<!--  Explain the reason behind this change. What problem does it solve?  -->  
- Needed a clean way to populate admin users for assigning course teachers  
- Makes it easier for the frontend to fetch only relevant user data  
- Keeps API logic modular and role-based  

## 🚀 Changes included  
<!--  List the specific changes made in this PR.  -->  
- [x] Added `getAdminUsers` service and controller function  
- [x] Modified `userRoutes.ts` to include `/admins` endpoint  
- [x] Updated Swagger docs that return `_id` and `username` for admin list  

## 🔹 Why is this important?  
<!--  Provide additional context on why these changes matter.  -->  
- Allows the frontend to list only valid admin users as course teachers  
- Keeps the user list output clean and minimal for dropdowns  
- Aligns with role-based access control across the app  

## 🔍 Benefits  
✔ **Security** – Admin-only route protected by auth middleware  
✔ **Data Integrity** – Avoids exposing full user data unnecessarily  
✔ **Performance** – Returns only essential fields for UI use  
✔ **Usability** – Simplifies frontend teacher selection logic  

## 📝 How to test?  
<!--  Step-by-step guide to test this PR.  -->  
1️⃣ Start the server (`npm run start-dev`).  
2️⃣ Authenticate as an admin using `POST /api/auth/login`.  
3️⃣ Use Postman to send `GET /api/users/admins` with a valid token.  
4️⃣ Verify that only users with role `admin` are returned.  
5️⃣ Confirm the response includes only `_id` and `username`.  
6️⃣ Try without a token or as a non-admin → should return `401` or `403`.  

## ✅ Checklist  
<!--  Mark completed tasks with `[x]` before submitting the PR.  -->  
- [x] Authentication and access control implemented (if applicable).  
- [x] API responses return correct status codes.  
- [x] No breaking changes introduced.  
- [x] Documentation updated (Swagger).